### PR TITLE
added custom link formatter

### DIFF
--- a/src/Datatables.php
+++ b/src/Datatables.php
@@ -9,6 +9,7 @@ class Datatables
     public const LINK_TYPE_POST = 'POST';
     public const LINK_TYPE_PUT = 'PUT';
     public const LINK_TYPE_DELETE = 'DELETE';
+	public const LINK_TYPE_CUSTOM = 'CUSTOM';
 
     public static function postLinkMethods()
     {

--- a/src/View/Helper/DatatableHelper.php
+++ b/src/View/Helper/DatatableHelper.php
@@ -675,10 +675,10 @@ class DatatableHelper extends Helper
 				}
 				$output = new $link['formatter']($this,$link);
 
-				if (method_exists($output, 'link')){
+				if (!method_exists($output, 'link')){
 					throw new \OutOfBoundsException("Method link is not found in class");
 				}
-				
+
 				break;
         case Datatables::LINK_TYPE_GET:
         default:

--- a/src/View/Helper/DatatableHelper.php
+++ b/src/View/Helper/DatatableHelper.php
@@ -670,10 +670,15 @@ class DatatableHelper extends Helper
             $output = new \CakeDC\Datatables\View\Formatter\Link\PostLink($this, $link);
             break;
 			case Datatables::LINK_TYPE_CUSTOM:
-				if (empty($link['formatter'])) {
-					throw new \OutOfBoundsException("please specify a custom formatter");
+				if (!is_callable($link['formatter'] ?? null)) {
+					throw new \OutOfBoundsException("Please specify a custom formatter");
 				}
 				$output = new $link['formatter']($this,$link);
+
+				if (method_exists($output, 'link')){
+					throw new \OutOfBoundsException("Method link is not found in class");
+				}
+				
 				break;
         case Datatables::LINK_TYPE_GET:
         default:

--- a/src/View/Helper/DatatableHelper.php
+++ b/src/View/Helper/DatatableHelper.php
@@ -669,7 +669,12 @@ class DatatableHelper extends Helper
         case Datatables::LINK_TYPE_POST:
             $output = new \CakeDC\Datatables\View\Formatter\Link\PostLink($this, $link);
             break;
-
+			case Datatables::LINK_TYPE_CUSTOM:
+				if (empty($link['formatter'])) {
+					throw new \OutOfBoundsException("please specify a custom formatter");
+				}
+				$output = new $link['formatter']($this,$link);
+				break;
         case Datatables::LINK_TYPE_GET:
         default:
             $output = new \CakeDC\Datatables\View\Formatter\Link\Link($this, $link);


### PR DESCRIPTION
Added functionality for using custom link formatters

Example:

```php
[
 'url' => ['action' => 'view', 'extra' => ("/' + obj.id + '")],
 'label' => '<i class="fa fa-long-arrow-alt-up mx-1" onclick="modalView(obj.id)" data-bs-toggle="modal" data-modal type="modal-xl" ></i>',
 'type' => \CakeDC\Datatables\Datatables::LINK_TYPE_CUSTOM,
 'formatter' => CustomFormatter::class,
],
```