### PR TITLE
remove case, created js error

### DIFF
--- a/src/Datatable/Datatable.php
+++ b/src/Datatable/Datatable.php
@@ -178,7 +178,7 @@ class Datatable
                             });
                             break;
                         case 'input':
-                        case default:
+                        default:
                             title = cell.data('header') ?? '';
                             cell.html('<input type="text" style="width:100%;" placeholder="'+ title +'" />');
                             $(


### PR DESCRIPTION
Removed case before default because it otherwise will create a javascript error.