### PR TITLE
adding className as parameter for column so we can add custom classes

### DIFF
--- a/src/Datatable/Datatable.php
+++ b/src/Datatable/Datatable.php
@@ -539,6 +539,9 @@ class Datatable
                 if ($key['width'] ?? null) {
                     $output .= "\nwidth: '{$key['width']}',";
                 }
+				if ($key['className'] ?? null) {
+					$output .= "\nclassName: '{$key['className']}',";
+				}
             }
             $output .= '}';
 


### PR DESCRIPTION
Added the functionality to add a class to column, this can be handy if you have a class actions for example to style that column.

```php
[
        'name' => 'actions',
       'className' => 'actions',
    ],
```
I used the naming convention of the datatables plugin for the functionality.