### PR TITLE
Added possibility to have 2 libaries for mulitselect

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,4 +358,12 @@ $this->Datatable->setCallbackCreatedRow(
         }
     }'
 );
-``
+```
+
+# Change library of multiselect
+
+The default is jquery-ui multiselect, if you want to change this you can change it in the configuration or like the code example below
+
+```php
+$this->Datatable->getInstance()->setConfig('multiSelectType', 'select2');
+```

--- a/src/Datatable/Datatable.php
+++ b/src/Datatable/Datatable.php
@@ -76,6 +76,7 @@ class Datatable
             'headersAttrsTr' => [],
             'headersAttrsTh' => [],
         ],
+		'multiSelectType' => 'jquery-ui',
         'rowActions' => [
             'name' => 'actions',
             'orderable' => 'false',
@@ -312,20 +313,24 @@ class Datatable
                     :onCompleteCallback
                     //column search
                     :columnSearch
+                    
+                    :multiSelectCallback
                 },
             });
 
             dt.css(:tableCss);
-            if( jQuery.isFunction( 'select2' ) ) {
-                $(function(){
-                    $(function(){
-                        // for execute the select2 plugin after all events are loaded
-                        $('.form-select-multiple').select2();
-                    });
-                });
-            }
         });
     DATATABLE_CONFIGURATION;
+
+	protected $datatableJqueryUITemplate = <<<JQUERYUI_CONFIGURATION
+			if ($.fn.multiselect) { $(function(){ $('.form-select-multiple').multiselect(); }); }
+	JQUERYUI_CONFIGURATION;
+
+
+	protected $datatableSelect2Template = <<<SELECT2_CONFIGURATION
+			if($.fn.select2) { $(function(){ $('.form-select-multiple').select2();}); }
+	SELECT2_CONFIGURATION;
+
 
     /**
      * @param Helper $Helper
@@ -462,6 +467,7 @@ class Datatable
             'onCompleteCallback' => $this->getConfig('onCompleteCallback') ? $this->getConfig('onCompleteCallback') : 'null',
             'columnSearch' => $this->getConfig('columnSearch') ? $this->columnSearchTemplate : '',
             'tableCss' => json_encode($this->getConfig('tableCss')),
+			'multiSelectCallback' => $this->getConfig('multiSelectType') === 'jquery-ui' ? $this->datatableJqueryUITemplate : $this->datatableSelect2Template,
         ];
 
         if ($this->getConfig('createdRow')) {

--- a/src/Datatable/Datatable.php
+++ b/src/Datatable/Datatable.php
@@ -19,6 +19,7 @@ class Datatable
 {
     use InstanceConfigTrait;
 
+
     /**
      * @var string
      */
@@ -34,6 +35,11 @@ class Datatable
      *
      * @var array<string, mixed>
      */
+
+
+	const MULTI_SELECT_TYPE_SELECT2 = 'select2';
+	const MULTI_SELECT_TYPE_JQUERY_UI = 'jquery-ui';
+
     protected $_defaultConfig = [
         'processing' => true,
         'serverSide' => true,
@@ -76,7 +82,7 @@ class Datatable
             'headersAttrsTr' => [],
             'headersAttrsTh' => [],
         ],
-		'multiSelectType' => 'jquery-ui',
+		'multiSelectType' => self::MULTI_SELECT_TYPE_SELECT2,
         'rowActions' => [
             'name' => 'actions',
             'orderable' => 'false',


### PR DESCRIPTION
In this branch i fixed the bug where the multiselect library wasn't loading after datatable was initialized. I moved logic to initComplete callback. I also added configuration option to switch between jquery-ui multiselect (default) and select2 because i don't know if someone was using it already. 

